### PR TITLE
Validate aliases

### DIFF
--- a/src/bin/avahi-alias-daemon.rs
+++ b/src/bin/avahi-alias-daemon.rs
@@ -70,7 +70,7 @@ fn load_aliases(
         file_name,
         last_modified.format(&Rfc3339).unwrap()
     );
-    AliasesFile::from_file(file_name)
+    AliasesFile::from_file(file_name, true)
 }
 
 fn publish_aliases<'a>(

--- a/src/bin/avahi-alias-daemon.rs
+++ b/src/bin/avahi-alias-daemon.rs
@@ -33,6 +33,7 @@ fn load_publish_loop(file_name: &str, sleep_duration: time::Duration) -> Result<
     let mut modified_size = ModifiedSize { last_modified: time::UNIX_EPOCH, len: 0 };
 
     loop {
+        log::debug!("Retrieving metadata for {:?}", file_name);
         let new_modified_size = get_metadata(file_name)?;
         //.with_context(|| format!("could not load aliases from {:?}", file_name))?;
         if new_modified_size != modified_size {
@@ -49,7 +50,6 @@ fn load_publish_loop(file_name: &str, sleep_duration: time::Duration) -> Result<
 }
 
 fn get_metadata(file_name: &str) -> Result<ModifiedSize, ErrorWrapper> {
-    log::debug!("Retrieving metadata for {:?}", file_name);
     match fs::metadata(file_name) {
         Ok(metadata) => Ok(ModifiedSize {
             last_modified: metadata.modified().unwrap(),
@@ -82,8 +82,11 @@ fn publish_aliases<'a>(
         file_name,
         last_modified.format(&Rfc3339).unwrap()
     );
-    for alias in aliases_file.aliases() {
-        log::info!("Publishing alias {}", alias);
+    for alias in aliases_file.all_aliases() {
+        match alias {
+            Ok(a) => log::info!("Publishing alias {}", a),
+            Err(a) => log::info!(r#"WARNING: invalid alias "{}" ignored"#, a),
+        }
     }
     log::info!(
         "Published aliases from {:?} (modified {})",

--- a/src/bin/avahi-alias.rs
+++ b/src/bin/avahi-alias.rs
@@ -12,7 +12,7 @@ fn main(opts: CommandOpts) {
     let result = match opts.cmd {
         Command::Add { aliases } => add(&opts.common.file, &aliases),
         Command::List {} => list(&opts.common.file),
-        Command::Remove { aliases } => remove(&opts.common.file, &aliases),
+        Command::Remove { aliases, force } => remove(&opts.common.file, &aliases, force),
     };
     if let Err(error) = result {
         log::error!("Error: {}", error);
@@ -20,11 +20,13 @@ fn main(opts: CommandOpts) {
 }
 
 fn add(filename: &str, arg_aliases: &[String]) -> Result<(), ErrorWrapper> {
+    // Validate command line aliases
     validate_aliases(arg_aliases)?;
-    let aliases_file = AliasesFile::from_file(filename)?;
-    aliases_file.is_valid()?;
-    let file_aliases: HashSet<&str> = aliases_file.aliases().into_iter().collect();
-    let (_, new_aliases) = split_aliases(&file_aliases, arg_aliases);
+    // Load the avahi-aliases file. (fails if there are invalid aliases.)
+    let aliases_file = AliasesFile::from_file(filename, false)?;
+    // new_aliases are commane line aliases not already in the file (don't add dups!).
+    let (_, new_aliases) =
+        split_aliases(&aliases_file.aliases().into_iter().collect(), arg_aliases);
     for alias in new_aliases.iter() {
         log::info!("Adding {:?} to {}", alias, filename);
     }
@@ -32,7 +34,7 @@ fn add(filename: &str, arg_aliases: &[String]) -> Result<(), ErrorWrapper> {
 }
 
 fn list(filename: &str) -> Result<(), ErrorWrapper> {
-    let aliases_file = AliasesFile::from_file(filename)?;
+    let aliases_file = AliasesFile::from_file(filename, true)?;
     for alias in aliases_file.all_aliases() {
         match alias {
             Ok(alias) => println!("{}", alias),
@@ -44,16 +46,26 @@ fn list(filename: &str) -> Result<(), ErrorWrapper> {
     Ok(())
 }
 
-fn remove(filename: &str, arg_aliases: &[String]) -> Result<(), ErrorWrapper> {
+fn remove(filename: &str, arg_aliases: &[String], force: bool) -> Result<(), ErrorWrapper> {
+    // Validate command line aliases
     validate_aliases(arg_aliases)?;
-    let aliases_file = AliasesFile::from_file(filename)?;
-    aliases_file.is_valid()?;
-    let file_aliases: HashSet<&str> = aliases_file.aliases().into_iter().collect();
-    let (extant_aliases, _) = split_aliases(&file_aliases, arg_aliases);
+    // Load the avahi-aliases file. (Fails if there are invalid aliases
+    // unless --force is in play.)
+    let aliases_file = AliasesFile::from_file(filename, force)?;
+    // If --force and there are invalid aliases, delete them
+    if !aliases_file.invalid_aliases().is_empty() {
+        for alias in aliases_file.invalid_aliases().iter() {
+            log::info!("Removing invalid alias {:?} from {}", alias, filename);
+        }
+        aliases_file.remove(&aliases_file.invalid_aliases(), true)?;
+    }
+    // extant_aliases is the list of aliases to be removed
+    let (extant_aliases, _) =
+        split_aliases(&aliases_file.aliases().into_iter().collect(), arg_aliases);
     for alias in extant_aliases.iter() {
         log::info!("Removing alias {:?} from {}", alias, filename);
     }
-    aliases_file.remove(&extant_aliases)
+    aliases_file.remove(&extant_aliases, false)
 }
 
 fn split_aliases<'a>(

--- a/src/options.rs
+++ b/src/options.rs
@@ -32,7 +32,6 @@ pub struct CommonOpts {
     pub verbose: bool,
 
     /// Prints detailed and debug messages
-    /// Note: debug has presidence over verbose
     #[structopt(short, long, global = true)]
     pub debug: bool,
 
@@ -59,8 +58,12 @@ pub enum Command {
     #[structopt(about = "Remove Aliases")]
     Remove {
         /// Aliases to remove
-        #[structopt(name = "ALIAS", required = true)]
+        #[structopt(name = "ALIAS", required_unless = "force")]
         aliases: Vec<String>,
+
+        /// Force removal of invalid aliases
+        #[structopt(long, global = true)]
+        force: bool,
     },
 
     #[structopt(about = "List existing Aliases")]


### PR DESCRIPTION
- Implement alias validation functions.
- `avahi-alias list` adds warning to invalid aliases
- `avahi-alias add` displays an error and terminates without action if there are invalid aliases in the avahi-aliases file or on the command line.
- `avahi-alias remove` displays an errors and terminates without action if there are invalid aliases in the avahi-aliases file or on the command line. (Unless --force is specified.)
- `avahi-alias remove --force` removes invalid aliases from the avahi-aliases file (but still terminates for invalid aliases on the command line).
- `avahi-alias-daemon` logs warnings for invalid aliases found in the avahi-aliases file.
