### PR TITLE
Bug/32 Handle empty aliases file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avahi-aliases"
-version = "0.1.0"
+version = "0.1.1"
 authors = [ "Scott G. Ainsworth" ]
 edition = "2021"
 description = "Avahi aliases manager"

--- a/src/aliases_file.rs
+++ b/src/aliases_file.rs
@@ -30,6 +30,9 @@ impl<'a> AliasesFile {
         self.lines.iter().filter_map(|line| line.alias().map(|a| a.err()).flatten()).collect()
     }
 
+    /// Return the number of aliases
+    pub fn alias_count(&self) -> usize { self.aliases().len() }
+
     pub fn from_file(filename: &str, allow_invalid: bool) -> Result<Self, ErrorWrapper> {
         let mut file = fs::OpenOptions::new()
             .read(true)
@@ -121,6 +124,17 @@ mod tests {
             for i in 0..n {
                 assert_eq!(aliases_file.lines()[i].text(), format!("a{}.local", i));
             }
+        }
+    }
+
+    /// Ensure the alias count is correct.
+    #[test]
+    fn alias_count_returns_correct_count() {
+        for n in 0..5 {
+            let test_file = TestFile::new("data/test-avahi-aliases-count.txt", n, &[]);
+            let aliases_file = AliasesFile::from_file(test_file.file_name, false).unwrap();
+            assert_eq!(aliases_file.lines().len(), n);
+            assert_eq!(aliases_file.alias_count(), n);
         }
     }
 

--- a/src/bin/avahi-alias.rs
+++ b/src/bin/avahi-alias.rs
@@ -37,6 +37,10 @@ fn add(filename: &str, arg_aliases: &[String]) -> Result<(), ErrorWrapper> {
 
 fn list(filename: &str) -> Result<(), ErrorWrapper> {
     let aliases_file = AliasesFile::from_file(filename, true)?;
+    if aliases_file.alias_count() == 0 {
+        log::warn!(r#"No aliases in "{}""#, filename);
+        return Ok(());
+    }
     for alias in aliases_file.all_aliases() {
         match alias {
             Ok(alias) => println!("{}", alias),


### PR DESCRIPTION
- Add function `alias_count()` to the `AliasFile` struct.
- Update `avahi-alias list` to show a message when the aliases file is empty.
- Update `avahi-alias-daemon` to log a warning when the aliases file is empty. Previously, it aborted after trying to commit a zero-length Avahi entry group.
- Bump the patch level.

Closes #6 