### PR TITLE
Implement polling interval option

### DIFF
--- a/src/bin/avahi-alias-daemon.rs
+++ b/src/bin/avahi-alias-daemon.rs
@@ -34,7 +34,7 @@ fn exec(opts: DaemonOpts) -> Result<(), ErrorWrapper> {
     let file_name = opts.common.file.as_str();
     let avahi_client = AvahiClient::new()?;
     signon_avahi(&avahi_client)?;
-    load_publish_loop(&avahi_client, file_name, time::Duration::from_secs(5))?;
+    load_publish_loop(&avahi_client, file_name, time::Duration::new(opts.polling_interval, 0))?;
     Ok(())
 }
 
@@ -73,7 +73,7 @@ fn load_aliases(
 }
 
 fn load_publish_loop(
-    avahi_client: &AvahiClient, file_name: &str, sleep_duration: time::Duration,
+    avahi_client: &AvahiClient, file_name: &str, polling_interval: time::Duration,
 ) -> Result<(), ErrorWrapper> {
     let mut modified_size = ModifiedSize { last_modified: time::UNIX_EPOCH, len: 0 };
 
@@ -88,7 +88,7 @@ fn load_publish_loop(
         } else {
             log::debug!(r#"Alias file "{}" has not changed"#, file_name);
         }
-        thread::sleep(sleep_duration);
+        thread::sleep(polling_interval);
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -25,24 +25,24 @@ pub struct DaemonOpts {
     pub polling_interval: u64,
 
     /// Log to syslog (vice console)
-    #[structopt(short, long)]
+    #[structopt(long = "syslog")]
     pub syslog: bool,
 }
 
 #[derive(Debug, StructOpt)]
 pub struct CommonOpts {
     /// Prints detailed messages
-    #[structopt(short, long, global = true)]
+    #[structopt(short = "v", long = "verbose", global = true)]
     pub verbose: bool,
 
-    /// Prints detailed and debug messages
-    #[structopt(short, long, global = true)]
+    /// Prints detailed (verbose) and debug messages
+    #[structopt(short = "d", long = "debug", global = true)]
     pub debug: bool,
 
-    /// Sets the avahi-aliases file path
+    /// Sets the avahi-aliases file
     #[structopt(
-        short,
-        long,
+        short = "f",
+        long = "file",
         global = true,
         name = "ALIASES-FILE",
         default_value = "/etc/avahi/avahi-aliases"
@@ -66,7 +66,7 @@ pub enum Command {
         aliases: Vec<String>,
 
         /// Force removal of invalid aliases
-        #[structopt(long, global = true)]
+        #[structopt(long = "force", global = true)]
         force: bool,
     },
 
@@ -82,16 +82,16 @@ pub enum Command {
 mod test {
     use structopt::{self, StructOpt};
 
-    use super::{Command, CommandOpts, CommonOpts};
+    use super::*;
 
     //******************************************************************************************
-    // Flags
+    // Common Options
 
     #[test]
     fn debug_flag_works() {
-        assert_eq!(CommonOpts::from_iter([""]).debug, false);
-        assert_eq!(CommonOpts::from_iter(["", "-d"]).debug, true);
-        assert_eq!(CommonOpts::from_iter(["", "--debug"]).debug, true);
+        assert!(!CommonOpts::from_iter([""]).debug);
+        assert!(CommonOpts::from_iter(["", "-d"]).debug);
+        assert!(CommonOpts::from_iter(["", "--debug"]).debug);
     }
 
     #[test]
@@ -106,29 +106,87 @@ mod test {
 
     #[test]
     fn verbose_flag_works() {
-        assert_eq!(CommonOpts::from_iter([""]).verbose, false);
-        assert_eq!(CommonOpts::from_iter(["", "-v"]).verbose, true);
-        assert_eq!(CommonOpts::from_iter(["", "--verbose"]).verbose, true);
+        assert!(!CommonOpts::from_iter([""]).verbose);
+        assert!(CommonOpts::from_iter(["", "-v"]).verbose);
+        assert!(CommonOpts::from_iter(["", "--verbose"]).verbose);
     }
+
+    #[test]
+    fn empty_common_options_work_for_command() {
+        for cmd in ["add", "list", "remove"] {
+            let opts = CommandOpts::from_iter(match cmd {
+                "list" => vec!["", cmd],
+                _ => vec!["", cmd, "a0.local"],
+            });
+            assert!(!opts.common.debug);
+            assert_eq!(opts.common.file, "/etc/avahi/avahi-aliases");
+            assert!(!opts.common.verbose);
+        }
+    }
+
+    #[test]
+    fn long_common_options_work_for_command() {
+        for cmd in ["add", "list", "remove"] {
+            let opts = CommandOpts::from_iter(match cmd {
+                "list" => vec!["", cmd, "--verbose", "--debug", "--file", "avahi-aliases"],
+                _ => {
+                    vec!["", cmd, "--verbose", "--debug", "--file", "avahi-aliases", "a1.local"]
+                },
+            });
+            assert!(opts.common.debug);
+            assert_eq!(opts.common.file, "avahi-aliases");
+            assert!(opts.common.verbose);
+        }
+    }
+
+    #[test]
+    fn short_common_options_work_for_command() {
+        for cmd in ["add", "list", "remove"] {
+            let opts = CommandOpts::from_iter(match cmd {
+                "list" => vec!["", cmd, "-v", "-f", "avahi-aliases"],
+                _ => vec!["", cmd, "-v", "-f", "avahi-aliases", "a1.local"],
+            });
+            assert!(!opts.common.debug);
+            assert_eq!(opts.common.file, "avahi-aliases");
+            assert!(opts.common.verbose);
+        }
+    }
+
+    #[test]
+    fn empty_common_options_work_for_daemon() {
+        let opts = DaemonOpts::from_iter([""]);
+        assert!(!opts.common.debug);
+        assert_eq!(opts.common.file, "/etc/avahi/avahi-aliases");
+        assert!(!opts.common.verbose);
+    }
+
+    #[test]
+    fn long_common_options_work_for_daemon() {
+        let opts =
+            DaemonOpts::from_iter(["", "--verbose", "--debug", "--file", "avahi-aliases"]);
+        assert!(opts.common.debug);
+        assert_eq!(opts.common.file, "avahi-aliases");
+        assert!(opts.common.verbose);
+    }
+
+    #[test]
+    fn short_common_options_work_for_daemon() {
+        let opts = DaemonOpts::from_iter(["", "-v", "-f", "avahi-aliases"]);
+        assert!(!opts.common.debug);
+        assert_eq!(opts.common.file, "avahi-aliases");
+        assert!(opts.common.verbose);
+    }
+
 
     //******************************************************************************************
     // Add Command
 
     #[test]
-    fn add_command_works() {
+    fn add_command_yields_add_command_opts() {
         assert!(matches!(
             CommandOpts::from_iter(["", "add", "a1.local"]).cmd,
             Command::Add { .. }
         ));
-    }
-
-    #[test]
-    fn add_flags_work() {
-        let opts =
-            CommandOpts::from_iter(["", "add", "-v", "-d", "-f", "avahi-aliases", "a1.local"]);
-        assert!(opts.common.debug);
-        assert_eq!(opts.common.file, "avahi-aliases");
-        assert!(opts.common.verbose);
     }
 
     #[test]
@@ -164,73 +222,73 @@ mod test {
     // List Command
 
     #[test]
-    fn list_command_works() {
+    fn list_command_yields_list_command_opts() {
         assert!(matches!(CommandOpts::from_iter(["", "list"]).cmd, Command::List { .. }));
-    }
-
-    #[test]
-    fn list_flags_work() {
-        let opts = CommandOpts::from_iter(["", "list", "-v", "-d", "-f", "avahi-aliases"]);
-        assert!(opts.common.debug);
-        assert_eq!(opts.common.file, "avahi-aliases");
-        assert!(opts.common.verbose);
     }
 
     //******************************************************************************************
     // Remove Command
 
     #[test]
-    fn remove_command_works() {
+    fn remove_command_yields_remove_command_opts() {
         assert!(matches!(
             CommandOpts::from_iter(["", "remove", "a1.local"]).cmd,
             Command::Remove { .. }
         ));
     }
 
-    #[test]
-    fn remove_flags_work() {
-        let opts = CommandOpts::from_iter([
-            "",
-            "remove",
-            "-v",
-            "-d",
-            "-f",
-            "avahi-aliases",
-            "a1.local",
-        ]);
-        assert!(opts.common.debug);
-        assert_eq!(opts.common.file, "avahi-aliases");
-        assert!(opts.common.verbose);
-    }
+    //******************************************************************************************
+    // Command line aliases for add and remove subcommands
 
     #[test]
-    fn remove_command_requires_at_least_one_alias() {
-        let opts = CommandOpts::from_iter_safe(["", "remove"]);
-        assert!(matches!(&opts.as_ref().unwrap_err(), clap::Error {
-            kind: clap::ErrorKind::MissingRequiredArgument,
-            ..
-        }));
-        assert!(opts.unwrap_err().message.contains("<ALIAS>"));
-    }
-
-    #[test]
-    fn remove_command_aliases_work() {
-        match CommandOpts::from_iter(["", "remove", "a1.local"]).cmd {
-            Command::Remove { aliases, .. } => {
-                assert_eq!(aliases.len(), 1);
-                assert_eq!(aliases[0], "a1.local")
-            },
-            _ => (),
-        };
-        match CommandOpts::from_iter(["", "remove", "a1.local", "a2.local"]).cmd {
-            Command::Add { aliases, .. } => {
-                assert_eq!(aliases.len(), 2);
-                assert_eq!(aliases[0], "a1.local");
-                assert_eq!(aliases[1], "a2.local")
-            },
-            _ => (),
+    fn command_line_aliases_are_available() {
+        for cmd in ["add", "remove"] {
+            match CommandOpts::from_iter(["", cmd, "a1.local"]).cmd {
+                Command::Remove { aliases, .. } => {
+                    assert_eq!(aliases.len(), 1);
+                    assert_eq!(aliases[0], "a1.local")
+                },
+                _ => (),
+            };
+            match CommandOpts::from_iter(["", cmd, "a1.local", "a2.local"]).cmd {
+                Command::Add { aliases, .. } => {
+                    assert_eq!(aliases.len(), 2);
+                    assert_eq!(aliases[0], "a1.local");
+                    assert_eq!(aliases[1], "a2.local")
+                },
+                _ => (),
+            }
         }
     }
+
+    #[test]
+    fn at_least_one_command_line_aliases_is_required() {
+        for cmd in ["add", "remove"] {
+            let opts = CommandOpts::from_iter_safe(["", cmd]);
+            assert!(matches!(&opts.as_ref().unwrap_err(), clap::Error {
+                kind: clap::ErrorKind::MissingRequiredArgument,
+                ..
+            }));
+            assert!(opts.unwrap_err().message.contains("<ALIAS>"));
+        }
+    }
+}
+
+//******************************************************************************************
+// Command line aliases for add and remove subcommands
+
+#[test]
+fn daemon_empty_options_work() {
+    let opts = DaemonOpts::from_iter([""]);
+    assert_eq!(opts.polling_interval, 30);
+    assert!(!opts.syslog);
+}
+
+#[test]
+fn daemon_long_options_work() {
+    let opts = DaemonOpts::from_iter(["", "--poll", "10", "--syslog", "--file"]);
+    assert_eq!(opts.polling_interval, 10);
+    assert!(opts.syslog);
 }
 
 // end

--- a/src/options.rs
+++ b/src/options.rs
@@ -20,6 +20,10 @@ pub struct DaemonOpts {
     #[structopt(flatten)]
     pub common: CommonOpts,
 
+    /// Change detection polling interval
+    #[structopt(short = "p", long = "poll", default_value = "30")]
+    pub polling_interval: u64,
+
     /// Log to syslog (vice console)
     #[structopt(short, long)]
     pub syslog: bool,


### PR DESCRIPTION
Implement a polling interval option for the `avahi-alias-daemon`:
- Add `--poll` option to 'options::DaemonOpts`.
- Add unit tests for 'options::DaemonOpts`.
- Add explicit short and option names.
- Clean up unit tests.

Closes #36