### PR TITLE
Merge LoggingError into ErrorWrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Cargo.lock
 **/*.rs.bk
 
 # working directories
+data
 test-results
 
 # Temporary files

--- a/src/bin/avahi-alias-daemon.rs
+++ b/src/bin/avahi-alias-daemon.rs
@@ -8,7 +8,7 @@ use structopt::StructOpt;
 use anyhow::Result;
 use avahi_aliases::{
     init_console_logging, init_syslog_logging, AliasesFile, AvahiClient, AvahiRecord,
-    DaemonOpts, ErrorWrapper, LoggingError,
+    DaemonOpts, ErrorWrapper,
 };
 
 #[derive(PartialEq)]
@@ -19,7 +19,7 @@ struct ModifiedSize {
 
 #[paw::main]
 fn main(opts: DaemonOpts) {
-    match exec(opts) {
+    match inner_main(opts) {
         Ok(_) => std::process::exit(0),
         Err(error) => {
             log::error!("Error: {}", error);
@@ -28,7 +28,7 @@ fn main(opts: DaemonOpts) {
     }
 }
 
-fn exec(opts: DaemonOpts) -> Result<(), ErrorWrapper> {
+fn inner_main(opts: DaemonOpts) -> Result<(), ErrorWrapper> {
     init_logging(opts.common.verbose, opts.common.debug, opts.syslog)?;
     signon_app();
     let file_name = opts.common.file.as_str();
@@ -38,11 +38,11 @@ fn exec(opts: DaemonOpts) -> Result<(), ErrorWrapper> {
     Ok(())
 }
 
-fn init_logging(verbose: bool, debug: bool, syslog: bool) -> Result<(), LoggingError> {
+fn init_logging(verbose: bool, debug: bool, syslog: bool) -> Result<(), ErrorWrapper> {
     match syslog {
         true => init_syslog_logging(verbose, debug),
         false => {
-            init_console_logging(verbose, debug);
+            init_console_logging(verbose, debug)?;
             Ok(())
         },
     }

--- a/src/bin/avahi-alias.rs
+++ b/src/bin/avahi-alias.rs
@@ -8,17 +8,20 @@ use avahi_aliases::{
 
 #[paw::main]
 fn main(opts: CommandOpts) {
-    init_console_logging(opts.common.verbose, opts.common.debug);
-    let result = match opts.cmd {
-        Command::Add { aliases } => add(&opts.common.file, &aliases),
-        Command::List {} => list(&opts.common.file),
-        Command::Remove { aliases, force } => remove(&opts.common.file, &aliases, force),
-    };
-    if let Err(error) = result {
+    if let Err(error) = inner_main(opts) {
         log::error!("Error: {}", error);
         std::process::exit(1);
     }
     std::process::exit(0);
+}
+
+fn inner_main(opts: CommandOpts) -> Result<(), ErrorWrapper> {
+    init_console_logging(opts.common.verbose, opts.common.debug)?;
+    match opts.cmd {
+        Command::Add { aliases } => add(&opts.common.file, &aliases),
+        Command::List {} => list(&opts.common.file),
+        Command::Remove { aliases, force } => remove(&opts.common.file, &aliases, force),
+    }
 }
 
 fn add(filename: &str, arg_aliases: &[String]) -> Result<(), ErrorWrapper> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use error::ErrorWrapper;
 mod line;
 pub use line::Line;
 mod logging;
-pub use logging::{init_console_logging, init_syslog_logging, LoggingError};
+pub use logging::{init_console_logging, init_syslog_logging};
 mod options;
 pub use options::{Command, CommandOpts, DaemonOpts};
 


### PR DESCRIPTION
- Eliminate `LoggingError;` merge its functions into `ErrorWrapper` (#17).
- Overhaul logging unit testing; refactor logging as needed (#40)
- Update other source as needed for logging changes (#17).

Closes #17 