### PR TITLE
Bug/40 coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,6 @@ anyhow = "1.0.45"
 regex = "1.5.4"
 sysinfo = "0.21.1"
 dbus = "0.9.5"
+num_enum = "0.5.4"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/avahi_client.rs
+++ b/src/avahi_client.rs
@@ -71,7 +71,7 @@ fn to_ascii(idna_name: &str) -> String { idna_name.to_owned() }
 //**********************************************************************************************
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use super::*;
 

--- a/src/avahi_client.rs
+++ b/src/avahi_client.rs
@@ -1,5 +1,6 @@
+//! As client interface to Avahi via D-Bus
+
 #![warn(clippy::all)]
-//! An interface to Avahi via D-Bus
 use std::time::Duration;
 
 use crate::ErrorWrapper;
@@ -21,6 +22,7 @@ mod record_class;
 pub use record_class::RecordClass;
 mod record_type;
 pub use record_type::RecordType;
+mod enums;
 
 const DEFAULT_TTL: Duration = Duration::from_secs(60);
 
@@ -33,22 +35,15 @@ impl<'a> AvahiClient {
     }
 
     pub fn encode_rdata(name: &str) -> Vec<u8> {
-        // TODO: convert encode_rdata to functional style
-        let mut rdata: Vec<u8> = Vec::<u8>::new();
+        // TODO: fix capacity to account for IDNA
+        let mut rdata: Vec<u8> = Vec::<u8>::with_capacity(name.len() + 1);
         for part in name.split('.').filter(|p| !p.is_empty()) {
-            rdata.extend([part.len().to_be_bytes().last().unwrap()]);
-            rdata.extend(to_ascii(part).as_bytes());
+            let encoded_part = to_ascii(part);
+            rdata.push(part.len() as u8);
+            rdata.extend(encoded_part.as_bytes());
         }
-        rdata.extend(&[0u8]);
+        rdata.push(0u8);
         rdata
-    }
-
-    pub fn encode_name(name: &str) -> String {
-        name.split('.')
-            .filter(|p| !p.is_empty())
-            .map(to_ascii)
-            .collect::<Vec<String>>()
-            .join(".")
     }
 
     pub fn new_entry_group(&self) -> Result<EntryGroup<'_>, ErrorWrapper> {
@@ -71,14 +66,21 @@ impl<'a> AvahiClient {
 /// Convert IDNA domains to ASCII (currently a no-op/passthrough)
 fn to_ascii(idna_name: &str) -> String { idna_name.to_owned() }
 
+//**********************************************************************************************
+// unit tests
+//**********************************************************************************************
+
 #[cfg(test)]
 mod test {
 
     use super::*;
 
-    static TEST_DATA: &[(&str, &[u8])] = &[
+    static TEST_RDATA: &[(&str, &[u8])] = &[
+        ("a.local", &[1, b'a', 5, b'l', b'o', b'c', b'a', b'l', 0]),
         ("a0.local", &[2, b'a', b'0', 5, b'l', b'o', b'c', b'a', b'l', 0]),
         ("xyzzy.local", &[5, b'x', b'y', b'z', b'z', b'y', 5, b'l', b'o', b'c', b'a', b'l', 0]),
+        ("a.z.local", &[1, b'a', 1, b'z', 5, b'l', b'o', b'c', b'a', b'l', 0]),
+        ("a..local", &[1, b'a', 5, b'l', b'o', b'c', b'a', b'l', 0]),
     ];
 
     #[test]
@@ -94,14 +96,18 @@ mod test {
     }
 
     #[test]
+    fn resource_records_are_encoded_correctly() {
+        for (alias, resource_record) in TEST_RDATA {
+            assert_eq!(*resource_record, AvahiClient::encode_rdata(alias).as_slice());
+        }
+    }
+
+    // TODO: All Linux-specific tests should be mocked
+
+    #[test]
     #[cfg(target_os = "linux")]
     fn dbus_creation_succeeds() -> Result<(), ErrorWrapper> {
-        let avahi_client = AvahiClient::new()?;
-        eprintln!("**** avahi_client.get_version() = {}", avahi_client.get_version()?);
-        eprintln!(
-            "**** avahi_client.get_host_name_fqdn() = {}",
-            avahi_client.get_host_name_fqdn()?
-        );
+        AvahiClient::new()?;
         Ok(())
     }
 
@@ -120,9 +126,26 @@ mod test {
     }
 
     #[test]
-    fn resource_records_are_created_correctly() {
-        for (alias, resource_record) in TEST_DATA {
-            assert_eq!(*resource_record, AvahiClient::encode_rdata(alias).as_slice());
-        }
+    #[cfg(target_os = "linux")]
+    fn get_host_name_fqdn_succeeds() -> Result<(), ErrorWrapper> {
+        eprintln!(
+            "**** avahi_client.get_host_name_fqdn() = {}",
+            AvahiClient::new()?.get_host_name_fqdn()?
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn get_proxy_succeeds() -> Result<(), ErrorWrapper> {
+        AvahiClient::new()?.get_proxy();
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn get_version_succeeds() -> Result<(), ErrorWrapper> {
+        eprintln!("**** avahi_client.get_version() = {}", AvahiClient::new()?.get_version()?);
+        Ok(())
     }
 }

--- a/src/avahi_client/avahi.rs
+++ b/src/avahi_client/avahi.rs
@@ -145,7 +145,7 @@ impl PartialEq<ClientState> for ServerState {
 //**********************************************************************************************
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use super::*;
 

--- a/src/avahi_client/dbus_constants.rs
+++ b/src/avahi_client/dbus_constants.rs
@@ -15,7 +15,7 @@ pub const DBUS_INTERFACE_ENTRY_GROUP: &str = "org.freedesktop.Avahi.EntryGroup";
 //**********************************************************************************************
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use super::*;
 

--- a/src/avahi_client/enums.rs
+++ b/src/avahi_client/enums.rs
@@ -1,0 +1,15 @@
+//! Macros to assist with DRY
+
+macro_rules! dbus_arg_iter_append {
+    ($name:ident) => {
+        /// Implement D-Bus argument append for $type
+        impl dbus::arg::Append for $name {
+            #[inline(always)]
+            fn append(self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(self); }
+            #[inline(always)]
+            fn append_by_ref(&self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(*self); }
+        }
+    };
+}
+
+pub(crate) use dbus_arg_iter_append;

--- a/src/avahi_client/interface.rs
+++ b/src/avahi_client/interface.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::all)]
-#[derive(Debug, Clone, Copy)]
+
+#[derive(
+    Clone, Copy, PartialEq, Eq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive, Debug,
+)]
+#[repr(i32)]
 pub enum Interface {
     Unspecified = -1,
 }
@@ -9,4 +13,48 @@ impl dbus::arg::Append for Interface {
     fn append(self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(self as i32); }
     #[inline(always)]
     fn append_by_ref(&self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(*self as i32); }
+}
+//**********************************************************************************************
+// Unit Tests
+//**********************************************************************************************
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    static TEST_DATA: &[(Interface, i32)] = &[(Interface::Unspecified, -1)];
+
+    #[test]
+    fn constants_are_correct() {
+        for datum in TEST_DATA {
+            assert_eq!(datum.1, datum.0.into())
+        }
+    }
+
+    #[test]
+    fn try_from_converts_valid_values_to_correct_variant() {
+        for datum in TEST_DATA {
+            let ok = Interface::try_from(datum.1);
+            eprintln!("try_converts_valid_value_to_correct_variant :: err={:?}", ok);
+            assert_eq!(datum.0, Interface::try_from(datum.1).unwrap())
+        }
+    }
+
+    #[test]
+    fn try_from_returns_error_for_invalid_values() {
+        for value in [-2, 0] {
+            let err = Interface::try_from(value);
+            eprintln!("try_from_returns_error_for_invalid_values :: err={:?}", err);
+            assert!(Interface::try_from(value).is_err());
+        }
+    }
+
+    #[test]
+    fn error_has_correct_message() {
+        eprintln!(":: {}", Interface::try_from(99).unwrap_err());
+        assert_eq!(
+            format!("{}", Interface::try_from(99).unwrap_err()),
+            "No discriminant in enum `Interface` matches the value `99`"
+        );
+    }
 }

--- a/src/avahi_client/interface.rs
+++ b/src/avahi_client/interface.rs
@@ -15,7 +15,7 @@ super::enums::dbus_arg_iter_append!(Interface);
 //**********************************************************************************************
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     static TEST_DATA: &[(Interface, i32)] = &[(Interface::Unspecified, -1)];

--- a/src/avahi_client/interface.rs
+++ b/src/avahi_client/interface.rs
@@ -8,12 +8,8 @@ pub enum Interface {
     Unspecified = -1,
 }
 
-impl dbus::arg::Append for Interface {
-    #[inline(always)]
-    fn append(self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(self as i32); }
-    #[inline(always)]
-    fn append_by_ref(&self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(*self as i32); }
-}
+super::enums::dbus_arg_iter_append!(Interface);
+
 //**********************************************************************************************
 // Unit Tests
 //**********************************************************************************************

--- a/src/avahi_client/protocol.rs
+++ b/src/avahi_client/protocol.rs
@@ -1,16 +1,17 @@
 #![warn(clippy::all)]
 
-#[derive(Debug, Clone, Copy)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive,
+)]
+#[repr(i32)]
 pub enum Protocol {
     /// Protocol not specified (or not needed)
     Unspecified = -1,
 
     /// Internet Protocol v4
-    #[allow(dead_code)]
     IPv4        = 0,
 
     /// Internet Protocol v6
-    #[allow(dead_code)]
     IPv6        = 1,
 }
 
@@ -19,4 +20,50 @@ impl dbus::arg::Append for Protocol {
     fn append(self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(self as i32); }
     #[inline(always)]
     fn append_by_ref(&self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(*self as i32); }
+}
+
+//**********************************************************************************************
+// Unit Tests
+//**********************************************************************************************
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    static TEST_DATA: &[(Protocol, i32)] =
+        &[(Protocol::Unspecified, -1), (Protocol::IPv4, 0), (Protocol::IPv6, 1)];
+
+    #[test]
+    fn constants_are_correct() {
+        for datum in TEST_DATA {
+            assert_eq!(datum.1, datum.0.into())
+        }
+    }
+
+    #[test]
+    fn try_from_converts_valid_values_to_correct_variant() {
+        for datum in TEST_DATA {
+            let ok = Protocol::try_from(datum.1);
+            eprintln!("try_converts_valid_value_to_correct_variant :: err={:?}", ok);
+            assert_eq!(datum.0, Protocol::try_from(datum.1).unwrap())
+        }
+    }
+
+    #[test]
+    fn try_from_returns_error_for_invalid_values() {
+        for value in [-2, 2] {
+            let err = Protocol::try_from(value);
+            eprintln!("try_from_returns_error_for_invalid_values :: err={:?}", err);
+            assert!(Protocol::try_from(value).is_err());
+        }
+    }
+
+    #[test]
+    fn error_has_correct_message() {
+        eprintln!(":: {}", Protocol::try_from(99).unwrap_err());
+        assert_eq!(
+            format!("{}", Protocol::try_from(99).unwrap_err()),
+            "No discriminant in enum `Protocol` matches the value `99`"
+        );
+    }
 }

--- a/src/avahi_client/protocol.rs
+++ b/src/avahi_client/protocol.rs
@@ -22,7 +22,7 @@ super::enums::dbus_arg_iter_append!(Protocol);
 //**********************************************************************************************
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     static TEST_DATA: &[(Protocol, i32)] =

--- a/src/avahi_client/protocol.rs
+++ b/src/avahi_client/protocol.rs
@@ -15,12 +15,7 @@ pub enum Protocol {
     IPv6        = 1,
 }
 
-impl dbus::arg::Append for Protocol {
-    #[inline(always)]
-    fn append(self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(self as i32); }
-    #[inline(always)]
-    fn append_by_ref(&self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(*self as i32); }
-}
+super::enums::dbus_arg_iter_append!(Protocol);
 
 //**********************************************************************************************
 // Unit Tests

--- a/src/avahi_client/record_class.rs
+++ b/src/avahi_client/record_class.rs
@@ -15,7 +15,7 @@ super::enums::dbus_arg_iter_append!(RecordClass);
 //**********************************************************************************************
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     static TEST_DATA: &[(RecordClass, u16)] = &[(RecordClass::In, 1)];

--- a/src/avahi_client/record_class.rs
+++ b/src/avahi_client/record_class.rs
@@ -8,11 +8,7 @@ pub enum RecordClass {
     In = 1,
 }
 
-impl dbus::arg::Append for RecordClass {
-    #[inline(always)]
-    fn append(self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(self as u16); }
-    #[inline(always)]
-    fn append_by_ref(&self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(*self as u16); }
+super::enums::dbus_arg_iter_append!(RecordClass);
 
 //**********************************************************************************************
 // Unit Tests

--- a/src/avahi_client/record_class.rs
+++ b/src/avahi_client/record_class.rs
@@ -1,6 +1,9 @@
 #![warn(clippy::all)]
 
-#[derive(Debug, Clone, Copy)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive,
+)]
+#[repr(u16)]
 pub enum RecordClass {
     In = 1,
 }
@@ -10,4 +13,48 @@ impl dbus::arg::Append for RecordClass {
     fn append(self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(self as u16); }
     #[inline(always)]
     fn append_by_ref(&self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(*self as u16); }
+
+//**********************************************************************************************
+// Unit Tests
+//**********************************************************************************************
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    static TEST_DATA: &[(RecordClass, u16)] = &[(RecordClass::In, 1)];
+
+    #[test]
+    fn constants_are_correct() {
+        for datum in TEST_DATA {
+            assert_eq!(datum.1, datum.0.into())
+        }
+    }
+
+    #[test]
+    fn try_from_converts_valid_values_to_correct_variant() {
+        for datum in TEST_DATA {
+            let ok = RecordClass::try_from(datum.1);
+            eprintln!("try_converts_valid_value_to_correct_variant :: err={:?}", ok);
+            assert_eq!(datum.0, RecordClass::try_from(datum.1).unwrap())
+        }
+    }
+
+    #[test]
+    fn try_from_returns_error_for_invalid_values() {
+        for value in [0, 2] {
+            let err = RecordClass::try_from(value);
+            eprintln!("try_from_returns_error_for_invalid_values :: err={:?}", err);
+            assert!(RecordClass::try_from(value).is_err());
+        }
+    }
+
+    #[test]
+    fn error_has_correct_message() {
+        eprintln!(":: {}", RecordClass::try_from(99).unwrap_err());
+        assert_eq!(
+            format!("{}", RecordClass::try_from(99).unwrap_err()),
+            "No discriminant in enum `RecordClass` matches the value `99`"
+        );
+    }
 }

--- a/src/avahi_client/record_type.rs
+++ b/src/avahi_client/record_type.rs
@@ -1,42 +1,37 @@
 #![warn(clippy::all)]
-#[derive(Debug, Clone, Copy)]
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, num_enum::IntoPrimitive, num_enum::TryFromPrimitive,
+)]
+#[repr(u16)]
 pub enum RecordType {
     /// IPv4 Address record
-    #[allow(dead_code)]
     A     = 1,
 
     /// Name Server record
-    #[allow(dead_code)]
     Ns    = 2,
 
     /// Canonical Name record
     Cname = 5,
 
     /// Start of Authority record
-    #[allow(dead_code)]
     Soa   = 6,
     /// Pointer (reverse lookup) record
-    #[allow(dead_code)]
     Ptr   = 12,
 
     /// Host Informattion record
-    #[allow(dead_code)]
     Hinfo = 13,
 
     /// Mail Exchanger record
-    #[allow(dead_code)]
     Mx    = 15,
 
     /// Text record
-    #[allow(dead_code)]
     Txt   = 16,
 
     /// IPv6 address record
-    #[allow(dead_code)]
     Aaa   = 28,
 
     /// Service record
-    #[allow(dead_code)]
     Srv   = 33,
 }
 
@@ -45,4 +40,59 @@ impl dbus::arg::Append for RecordType {
     fn append(self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(self as u16); }
     #[inline(always)]
     fn append_by_ref(&self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(*self as u16); }
+
+//**********************************************************************************************
+// Unit Tests
+//**********************************************************************************************
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    static TEST_DATA: &[(RecordType, u16)] = &[
+        (RecordType::A, 1),
+        (RecordType::Ns, 2),
+        (RecordType::Cname, 5),
+        (RecordType::Soa, 6),
+        (RecordType::Ptr, 12),
+        (RecordType::Hinfo, 13),
+        (RecordType::Mx, 15),
+        (RecordType::Txt, 16),
+        (RecordType::Aaa, 28),
+        (RecordType::Srv, 33),
+    ];
+
+    #[test]
+    fn constants_are_correct() {
+        for datum in TEST_DATA {
+            assert_eq!(datum.1, datum.0.into())
+        }
+    }
+
+    #[test]
+    fn try_from_converts_valid_values_to_correct_variant() {
+        for datum in TEST_DATA {
+            let ok = RecordType::try_from(datum.1);
+            eprintln!("try_converts_valid_value_to_correct_variant :: err={:?}", ok);
+            assert_eq!(datum.0, RecordType::try_from(datum.1).unwrap())
+        }
+    }
+
+    #[test]
+    fn try_from_returns_error_for_invalid_values() {
+        for value in [0, 3, 4, 7, 8, 11, 14, 17, 27, 34] {
+            let err = RecordType::try_from(value);
+            eprintln!("try_from_returns_error_for_invalid_values :: err={:?}", err);
+            assert!(RecordType::try_from(value).is_err());
+        }
+    }
+
+    #[test]
+    fn error_has_correct_message() {
+        eprintln!(":: {}", RecordType::try_from(99).unwrap_err());
+        assert_eq!(
+            format!("{}", RecordType::try_from(99).unwrap_err()),
+            "No discriminant in enum `RecordType` matches the value `99`"
+        );
+    }
 }

--- a/src/avahi_client/record_type.rs
+++ b/src/avahi_client/record_type.rs
@@ -42,7 +42,7 @@ super::enums::dbus_arg_iter_append!(RecordType);
 //**********************************************************************************************
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     static TEST_DATA: &[(RecordType, u16)] = &[

--- a/src/avahi_client/record_type.rs
+++ b/src/avahi_client/record_type.rs
@@ -35,11 +35,7 @@ pub enum RecordType {
     Srv   = 33,
 }
 
-impl dbus::arg::Append for RecordType {
-    #[inline(always)]
-    fn append(self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(self as u16); }
-    #[inline(always)]
-    fn append_by_ref(&self, ia: &mut dbus::arg::IterAppend<'_>) { ia.append(*self as u16); }
+super::enums::dbus_arg_iter_append!(RecordType);
 
 //**********************************************************************************************
 // Unit Tests

--- a/src/bin/avahi-alias-daemon.rs
+++ b/src/bin/avahi-alias-daemon.rs
@@ -82,7 +82,7 @@ fn load_publish_loop(
         let new_modified_size = get_metadata(file_name)?;
         if new_modified_size != modified_size {
             let aliases_file = load_aliases(file_name, &new_modified_size)?;
-            log::info!(r#"Loaded {} aliases from "{}""#, aliases_file.alias_count(), file_name,);
+            log::info!(r#"Loaded {} aliases from "{}""#, aliases_file.alias_count(), file_name);
             publish_aliases(avahi_client, &aliases_file, file_name, &new_modified_size)?;
             modified_size = new_modified_size;
         } else {
@@ -113,10 +113,9 @@ fn publish_aliases<'a>(
     let group = avahi_client.new_entry_group()?;
     for alias in aliases_file.all_aliases() {
         match alias {
-            Ok(a) => {
-                log::info!("Publishing alias {}", a);
-                let cname = AvahiClient::encode_name(a);
-                let cname_record = AvahiRecord::new_cname(&cname, 60, &rdata);
+            Ok(alias) => {
+                log::info!("Publishing alias {}", alias);
+                let cname_record = AvahiRecord::new_cname(alias, 60, &rdata);
                 group.add_record(cname_record)?;
             },
             Err(a) => log::info!(r#"WARNING: invalid alias "{}" ignored"#, a),

--- a/src/error.rs
+++ b/src/error.rs
@@ -183,7 +183,7 @@ impl ErrorWrapper {
 //**********************************************************************************************
 
 #[cfg(test)]
-mod test {
+mod tests {
     use ErrorWrapper::*;
 
     use super::*;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -71,9 +71,10 @@ mod tests {
 
     #[test]
     fn init_console_logging_works() {
-        init_console_logging(true, false).unwrap_or_else(|error| {
-            eprintln!(r#"Could completely test "init_console_logging": {:?}"#, error);
-        });
+        // There is a good chance that logging is already initialized by the testing
+        // system; thus, an Err(...) result is ignored.
+        // The result is less than perfect testing--c'est la guerre!
+        let _ = init_console_logging(true, false);
     }
 
     #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,10 +7,10 @@ pub use structopt::StructOpt;
 pub struct CommandOpts {
     /// The subcommand to execute
     #[structopt(subcommand)]
-    pub cmd: Command,
+    pub cmd: Command, // #[grcov(off)]
 
     #[structopt(flatten)]
-    pub common: CommonOpts,
+    pub common: CommonOpts, // #[grcov(off)]
 }
 
 #[derive(Debug, StructOpt)]
@@ -18,7 +18,7 @@ pub struct CommandOpts {
 pub struct DaemonOpts {
     /// Common options (verbose, debug, & filename)
     #[structopt(flatten)]
-    pub common: CommonOpts,
+    pub common: CommonOpts, // #[grcov(off)]
 
     /// Change detection polling interval
     #[structopt(short = "p", long = "poll", default_value = "30")]
@@ -26,18 +26,18 @@ pub struct DaemonOpts {
 
     /// Log to syslog (vice console)
     #[structopt(long = "syslog")]
-    pub syslog: bool,
+    pub syslog: bool, // #[grcov(off)]
 }
 
 #[derive(Debug, StructOpt)]
 pub struct CommonOpts {
     /// Prints detailed messages
     #[structopt(short = "v", long = "verbose", global = true)]
-    pub verbose: bool,
+    pub verbose: bool, // #[grcov(off)]
 
     /// Prints detailed (verbose) and debug messages
     #[structopt(short = "d", long = "debug", global = true)]
-    pub debug: bool,
+    pub debug: bool, // #[grcov(off)]
 
     /// Sets the avahi-aliases file
     #[structopt(
@@ -67,7 +67,7 @@ pub enum Command {
 
         /// Force removal of invalid aliases
         #[structopt(long = "force", global = true)]
-        force: bool,
+        force: bool, // #[grcov(off)]
     },
 
     #[structopt(about = "List existing Aliases")]

--- a/src/options.rs
+++ b/src/options.rs
@@ -79,7 +79,7 @@ pub enum Command {
 //**********************************************************************************************
 
 #[cfg(test)]
-mod test {
+mod tests {
     use structopt::{self, StructOpt};
 
     use super::*;


### PR DESCRIPTION
- Create unit test coverage using `grcov`.
- Update `Makefile` to create coverage for `lib` target.
- Improve unit test coverage for `logging.rs`, `options.rs`, `avahi_aliases.rs`, Avahi enums.

Closes #40