### PR TITLE
Finish implementing spell checking

### DIFF
--- a/.cspell/custom-dictionary-folder-avahi-aliases-rs.txt
+++ b/.cspell/custom-dictionary-folder-avahi-aliases-rs.txt
@@ -2,5 +2,17 @@
 Ainsworth
 Airtonix
 avahi
+cname
+codegen
+dbus
+dups
+Freedesktop
 IDNA
 luarntlemercier
+rdata
+signon
+structopt
+sysinfo
+UNSPEC
+xyzzy
+zeroconf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,15 @@
             "addWords": true,
             "scope": "folder"
         }
-    }
+    },
+    "cSpell.ignorePaths": [
+        ".git/objects",
+        ".vscode",
+        ".vscode-insiders",
+        "node_modules",
+        "package-lock.json",
+        "src/avahi_dbus/entry_group.rs",
+        "src/avahi_dbus/server.rs",
+        "vscode-extension"
+    ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 default-run = "avahi-alias"
 
 [badges]
-maintainance = { status = "experimental" }
+maintenance = { status = "experimental" }
 
 [profile.release]
 debug = false

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -106,7 +106,7 @@ mod tests {
 
     static VALID_ALIASES: [&str; 4] = ["a.local", "xyzzy.local", "b0.local", "a-z.local"];
     static INVALID_ALIASES: [&str; 5] =
-        ["a. local", "xyzz*.local", ".local", "-.local", "a-.local"];
+        ["a. local", "xyzzy*.local", ".local", "-.local", "a-.local"];
 
     #[test]
     fn is_valid_returns_true_for_valid_alias() {

--- a/src/bin/avahi-alias.rs
+++ b/src/bin/avahi-alias.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use anyhow::{Result};
+use anyhow::Result;
 use avahi_aliases::{
     init_console_logging, validate_aliases, AliasesFile, Command, CommandOpts,
 };
@@ -30,7 +30,7 @@ fn add(filename: &str, arg_aliases: &[String]) -> Result<()> {
     validate_aliases(arg_aliases)?;
     // Load the avahi-aliases file. (fails if there are invalid aliases.)
     let aliases_file = AliasesFile::from_file(filename, false)?;
-    // new_aliases are commane line aliases not already in the file (don't add dups!).
+    // new_aliases are command line aliases not already in the file (don't add dups!).
     let (_, new_aliases) =
         split_aliases(&aliases_file.aliases().into_iter().collect(), arg_aliases);
     for alias in new_aliases.iter() {


### PR DESCRIPTION
Finish implementing spell checking using the VS Code Street Side Software code Spell Checker extension.

- Add spell checking configuration files
- Add "folder" dictionary.
- Correct misspellings.