### PR TITLE
Maint/51 housekeeping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     },
     "cSpell.ignorePaths": [
         ".git/objects",
+        ".rustfmt.toml",
         ".vscode",
         ".vscode-insiders",
         "node_modules",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,14 +5,20 @@
 		{
 			"type": "cargo",
 			"command": "check",
+			"args": ["+nightly"],
+			"env": {
+				"CARGO_INCREMENTAL": "0",
+				"RUSTFLAGS": "-Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zprofile -Zpanic_abort_tests",
+				"RUSTDOCFLAGS": "-Cpanic=abort"
+			},
 			"problemMatcher": [ "$rustc" ],
 			"group": "build",
-			"label": "rust: cargo check"
+			"label": "rust: cargo check",
 		},
 
 		{
-			"type": "cargo",
-			"command": "build",
+			"type": "shell",
+			"command": "make bin",
 			"problemMatcher": [ "$rustc" ],
 			"group": {
 				"kind": "build",
@@ -24,20 +30,21 @@
 
 		{
 			"type": "shell",
-			"command": ["cargo", "+nightly", "fmt" ],
+			"command": ["cargo", "+nightly", "fmt"],
 			"problemMatcher": [ "$rustc" ],
 			"group": "build",
 			"label": "rust: cargo fmt"
 		},
 
 		{
-			"type": "cargo",
-			"command": "test",
+			"type": "shell",
+			"command": "make test",
 			"problemMatcher": [ "$rustc" ],
 			"group": {
 				"kind": "test",
 				"isDefault": true
 			},
+			"dependsOn": ["rust: cargo fmt"],
 			"label": "rust: cargo test"
 		}
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .DEFAULT: test
 
-lib_source    := $(wildcard src/*.rs) $(wildcard src/avahi-client/*.rs src/avahi-client/*/*.rs)
-alias_source  := $(wildcard src/bin/avahi-alias/*.rs)
-daemon_source := $(wildcard src/bin/avahi-alias-daemon/*.rs)
+LIB_SOURCE    := $(wildcard src/*.rs) $(wildcard src/avahi-client/*.rs src/avahi-client/*/*.rs)
+ALIAS_SOURCE  := $(wildcard src/bin/avahi-alias/*.rs)
+DAEMON_SOURCE := $(wildcard src/bin/avahi-alias-daemon/*.rs)
 
 ########################################
 # CONVENIENCE TARGETS
@@ -64,7 +64,7 @@ doc: target/doc/avahi_aliases/index.html
 
 bin: target/debug/avahi-alias target/debug/avahi-alias-daemon
 
-target/debug/libavahi_aliases.rlib: $(lib_source) clippy
+target/debug/libavahi_aliases.rlib: $(LIB_SOURCE) clippy
 	rm -f *.profraw target/debug/deps/avahi_alias*.gcd[ao]
 	rm -f target/debug/deps/avahi_aliases-*.gcda
 	$(DEBUG_ENV) cargo +nightly build --lib
@@ -73,10 +73,10 @@ target/doc/avahi_aliases/index.html: lib
 	rm -fr $(@D)
 	$(DEBUG_ENV) cargo +nightly doc --no-deps --document-private-items
 
-target/debug/avahi-alias: $(alias_source) lib
+target/debug/avahi-alias: $(ALIAS_SOURCE) lib
 	$(DEBUG_ENV) cargo +nightly build --bin $(@F)
 
-target/debug/avahi-alias-daemon: $(daemon_source) lib
+target/debug/avahi-alias-daemon: $(DAEMON_SOURCE) lib
 	$(DEBUG_ENV) cargo +nightly build --bin $(@F)
 
 ########################################
@@ -100,14 +100,14 @@ release-test:
 release-clippy:
 	$(RELEASE_ENV) cargo +nightly clippy -- -A clippy::all
 
-target/release/libavahi_aliases.rlib: $(lib_source) release-clippy
+target/release/libavahi_aliases.rlib: $(LIB_SOURCE) release-clippy
 	$(RELEASE_ENV) cargo build --release --lib
 
-target/release/avahi-alias: $(alias_source) release-lib
+target/release/avahi-alias: $(ALIAS_SOURCE) release-lib
 	$(RELEASE_ENV) cargo build --release --bin $(@F)
 	strip $@
 
-target/release/avahi-alias-daemon: $(daemon_source) release-lib
+target/release/avahi-alias-daemon: $(DAEMON_SOURCE) release-lib
 	$(RELEASE_ENV) cargo build --release --bin $(@F)
 	strip $@
 
@@ -153,9 +153,9 @@ dofmt:
 	cargo +nightly fmt -v
 
 dump:
-	@echo "lib_source    = $(lib_source)"
-	@echo "alias_source  = $(alias_source)"
-	@echo "daemon_source = $(daemon_source)"
+	@echo "LIB_SOURCE    = $(LIB_SOURCE)"
+	@echo "ALIAS_SOURCE  = $(ALIAS_SOURCE)"
+	@echo "DAEMON_SOURCE = $(DAEMON_SOURCE)"
 
 # `rust-setup` This is likely incomplete
 setup-rust:

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -3,7 +3,7 @@
 #![warn(clippy::all)]
 
 pub fn encode_rdata(name: &str) -> Vec<u8> {
-    // TODO: fix capacity to account for IDNA
+    // TODO(#24) fix capacity to account for IDNA
     let mut rdata: Vec<u8> = Vec::<u8>::with_capacity(name.len() + 1);
     for part in name.split('.').filter(|p| !p.is_empty()) {
         let encoded_part = to_ascii(part);


### PR DESCRIPTION
- Exclude .rustfmt from spell check.
- Synchronize Makefile and tasks.json build options to minimize rebuilds.
- Makefile inconsistencies cleanup.
- Add issue number to in-code to-do comments.

Closes #51 
